### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/aiw-devops/c6e1359c-f08f-4812-9b1d-5eba5393cfcc/14732f8b-6206-4906-a0e6-2df0429ea71a/_apis/work/boardbadge/3b3ad661-afc4-46ef-ab39-ee509aa1d314)](https://dev.azure.com/aiw-devops/c6e1359c-f08f-4812-9b1d-5eba5393cfcc/_boards/board/t/14732f8b-6206-4906-a0e6-2df0429ea71a/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1481](https://dev.azure.com/aiw-devops/c6e1359c-f08f-4812-9b1d-5eba5393cfcc/_workitems/edit/1481). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.